### PR TITLE
feat: Added medianlow and medianHigh functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This library is a collection of functions that perform statistical calculations 
 * [covarianceSample](#sample-covariance)
 * [max](#max)
 * [median](#median)
+* [medianLow](#medianLow)
+* [medianHigh](#medianHigh)
 * [min](#min)
 * [pearson](#pearson-correlation-coefficient)
 * [standardDeviationPopulation](#population-standard-deviation)
@@ -124,6 +126,34 @@ Returns the [median value](http://en.wikipedia.org/wiki/Median) from the array.
 ```Swift
 Sigma.median([1, 12, 19.5, 3, -5])
 // Result: 3
+```
+
+### Median Low
+
+Returns the [median value](http://en.wikipedia.org/wiki/Median) from the array.
+
+**Note**:
+
+* Returns nil when the array is empty.
+* Returns the lower of the two middle values if there is an even number of items in the array.
+
+```Swift
+Sigma.median([1, 12, 19.5, 10, 3, -5])
+// Result: 3
+```
+
+### Median High
+
+Returns the [median value](http://en.wikipedia.org/wiki/Median) from the array.
+
+**Note**:
+
+* Returns nil when the array is empty.
+* Returns the higher of the two middle values if there is an even number of items in the array.
+
+```Swift
+Sigma.median([1, 12, 19.5, 10, 3, -5])
+// Result: 10
 ```
 
 ### Sample variance
@@ -320,6 +350,7 @@ If you need help or want to extend the library feel free to create an issue or s
 ## Contributors
 
 * [Thomas Fankhauser](https://github.com/southdesign)
+* [John Clema](https://github.com/JohnClema)
 
 ## License
 

--- a/SigmaSwiftStatistics/Sigma.swift
+++ b/SigmaSwiftStatistics/Sigma.swift
@@ -110,7 +110,7 @@ public struct Sigma {
     let sorted = values.sort { $0 < $1 }
     
     if count % 2 == 0 {
-      // Event number of items - return the mean of two middle values
+      // Even number of items - return the mean of two middle values
       let leftIndex = Int(count / 2 - 1)
       let leftValue = sorted[leftIndex]
       let rightValue = sorted[leftIndex + 1]
@@ -119,6 +119,55 @@ public struct Sigma {
       // Odd number of items - take the middle item.
       return sorted[Int(count / 2)]
     }
+  }
+  
+  /**
+   
+   Returns the central value from the array after it is sorted.
+   
+   http://en.wikipedia.org/wiki/Median
+   
+   - parameter values: Array of decimal numbers.
+   - returns: The median value from the array. Returns nil for an empty array. Returns the smaller of the two middle values if there is an even number of items in the array.
+   
+   Example
+   
+   Sigma.median([1, 12, 19.5, 3, -5]) // 3
+   
+   */
+  public static func medianLow(values: [Double]) -> Double? {
+    let count = Double(values.count)
+    if count == 0 { return nil }
+    let sorted = values.sort { $0 < $1 }
+    
+    if count % 2 == 0 {
+      // Even number of items - return the lower of the two middle values
+      return sorted[Int(count / 2) - 1]
+    } else {
+      // Odd number of items - take the middle item.
+      return sorted[Int(count / 2)]
+    }
+  }
+  
+  /**
+   
+   Returns the central value from the array after it is sorted.
+   
+   http://en.wikipedia.org/wiki/Median
+   
+   - parameter values: Array of decimal numbers.
+   - returns: The median value from the array. Returns nil for an empty array. Returns the greater of the two middle values if there is an even number of items in the array.
+   
+   Example
+   
+   Sigma.median([1, 12, 19.5, 3, -5, ]) // 3
+   
+   */
+  public static func medianHigh(values: [Double]) -> Double? {
+    let count = Double(values.count)
+    if count == 0 { return nil }
+    let sorted = values.sort { $0 < $1 }
+    return sorted[Int(count / 2)]
   }
   
   /**

--- a/SigmaSwiftStatisticsTests/SigmaTests.swift
+++ b/SigmaSwiftStatisticsTests/SigmaTests.swift
@@ -74,6 +74,48 @@ class SigmaTests: XCTestCase {
     XCTAssert(result == nil)
   }
   
+  // MARK: - Median Low
+  func testMedianLow_oddNumberOfItems() {
+    let result = Sigma.medianLow([1, 12, 19.5, 3, -5])!
+    XCTAssertEqual(3, result)
+  }
+  
+  func testMedianLow_eventNumberOfItems() {
+    let result = Sigma.medianLow([1, 12, 19.5, 3, -5, 8])!
+    XCTAssertEqual(3, result)
+  }
+  
+  func testMedianLow_oneItem() {
+    let result = Sigma.medianLow([2])!
+    XCTAssertEqual(2, result)
+  }
+  
+  func testMedianLow_whenEmpty() {
+    let result = Sigma.medianLow([])
+    XCTAssert(result == nil)
+  }
+  
+  //MARK: - Median High
+  func testMedianHigh_oddNumberOfItems() {
+    let result = Sigma.medianHigh([1, 12, 19.5, 3, -5])!
+    XCTAssertEqual(3, result)
+  }
+  
+  func testMedianHigh_eventNumberOfItems() {
+    let result = Sigma.medianHigh([1, 12, 19.5, 3, -5, 8])!
+    XCTAssertEqual(8, result)
+  }
+  
+  func testMedianHigh_oneItem() {
+    let result = Sigma.medianHigh([2])!
+    XCTAssertEqual(2, result)
+  }
+  
+  func testMedianHigh_whenEmpty() {
+    let result = Sigma.medianHigh([])
+    XCTAssert(result == nil)
+  }
+  
   // MARK: - Sample variance
   
   func testVarianceSample() {


### PR DESCRIPTION
Added median functions that provide low and high functions similar to python statistics ( https://docs.python.org/3/library/statistics.html ). These work as the median function when the number of data points is odd. Though when it is even, the larger of the two middle values is returned. This can be useful when using discrete data sets and you wish to keep them this way, rather than ending up with an interpolated output.